### PR TITLE
a few improvements

### DIFF
--- a/whatprovides
+++ b/whatprovides
@@ -107,7 +107,7 @@ if [ $# -lt 1 ]; then
 fi
 
 if ${REVERSE_MODE}; then
-	if ! grep -qP '^[a-z0-9_+\-]+$' <<< "$1"; then
+	if ! grep -qx '[a-z0-9_+-]\+' <<< "$1"; then
 		{
 			echo
 			echo "Error: package name '${1}' is not valid."
@@ -116,11 +116,22 @@ if ${REVERSE_MODE}; then
 		exit 1
 	fi
 
-	echo "SELECT owned_file FROM 'whatprovides' WHERE package_name == '${1}' ORDER BY owned_file;" | \
-		sqlite3 "${DB_PATH}" | awk "{ print \"${1}: \"\$0 }"
+	sqlite3 "${DB_PATH}" \
+		"SELECT owned_file FROM 'whatprovides' WHERE package_name == '${1}' ORDER BY owned_file" \
+		| awk "{ print \"${1}: \"\$0 }"
 else
-	echo "SELECT package_name FROM 'whatprovides' WHERE owned_file == '$(realpath "${1}")' ORDER BY package_name;" | \
-		sqlite3 "${DB_PATH}" | awk "{ print \$0\": $(realpath "${1}")\" }"
+	FILE="$(realpath "$1")"
+	if ! sqlite3 "${DB_PATH}" \
+		"SELECT package_name FROM 'whatprovides' WHERE owned_file == '$FILE' ORDER BY package_name" \
+		| awk "{ print \$0\": $FILE\" } END {if (NR == 0) exit 1 }"
+	then
+		{
+			echo
+			echo "Error: file '$1' is not found."
+			echo
+		} >&2
+		exit 1
+	fi
 fi
 
 exit 0


### PR DESCRIPTION
fixes #6
details:
grep doesn't need to be in perl mode, its `-x` is equivalent to `^...$`, and unmatched dashes don't need to be escaped
sqlite3 can take a single command as its 2nd argument
don't call realpath twice on the same file
and finally the fix for #6: output a "not found" error only when it wasn't in the database, relying on awk having no records piped to it

feel free to pick and choose what you take from this