### PR TITLE
vastly reduce database size and search time by not storing $PREFIX

### DIFF
--- a/update-whatprovides-db.sh
+++ b/update-whatprovides-db.sh
@@ -7,7 +7,9 @@
 set -e -u
 
 list_files() {
-	dpkg-deb -c "${1}" | grep -o "/data/data/com.termux/.*" | sed -E 's@(.*) ->..*@\1@g'
+	dpkg-deb -c "${1}" | grep -o "/data/data/com\.termux/files/.\+" \
+		| sed -E 's@(.*) ->..*@\1@g;s@/$@@g' \
+		| xargs -rd\\n realpath -sm --relative-base=$TERMUX_PREFIX --
 }
 
 write_sql_script() {

--- a/whatprovides
+++ b/whatprovides
@@ -118,12 +118,32 @@ if ${REVERSE_MODE}; then
 
 	sqlite3 "${DB_PATH}" \
 		"SELECT owned_file FROM 'whatprovides' WHERE package_name == '${1}' ORDER BY owned_file" \
-		| awk "{ print \"${1}: \"\$0 }"
+		| awk "NR == 1 { print \"${1}: /.\\n${1}: /data\\n${1}: /data/data\\n${1}: /data/data/com.termux\\n${1}: /data/data/com.termux/files\\n${1}: ${PREFIX}\" } { print \"${1}: ${PREFIX}/\"\$0 }"
 else
-	FILE="$(realpath "$1")"
+	NEWPREFIX=
+	FILE="$(realpath -sm "$1")"
+
+	if [[ "${PREFIX}/" = "${FILE}/"* || "${FILE}" = / ]]; then
+		# FILE is (((great...)grand)parent of) PREFIX, including root
+		if [ "${FILE}" = / ]; then
+			FILE=/.
+		fi
+
+		sqlite3 "${DB_PATH}" \
+			"SELECT DISTINCT package_name FROM 'whatprovides' ORDER BY package_name" \
+			| awk "{ print \$0\": ${FILE}\" }"
+		exit 0
+	fi
+
+	if [[ "${FILE}" = "${PREFIX}/"* ]]; then
+		# FILE is in PREFIX
+		FILE="${FILE##${PREFIX}/}"
+		NEWPREFIX="${PREFIX}/"
+	fi # else FILE is entirely separate from PREFIX (unlikely to be in DB)
+
 	if ! sqlite3 "${DB_PATH}" \
-		"SELECT package_name FROM 'whatprovides' WHERE owned_file == '$FILE' ORDER BY package_name" \
-		| awk "{ print \$0\": $FILE\" } END {if (NR == 0) exit 1 }"
+		"SELECT package_name FROM 'whatprovides' WHERE owned_file == '${FILE//\'/\'\'}' ORDER BY package_name" \
+		| awk "{ print \$0\": ${NEWPREFIX}${FILE}\" } END { if (NR == 0) exit 1 }"
 	then
 		{
 			echo


### PR DESCRIPTION
you'll need to reconstruct the database from scratch, only excluding `$TERMUX_PREFIX` and its (grand...)parents, and running everything through `realpath -sm --relative-base=$TERMUX_PREFIX` (you can deal with #8 at the same time if you're careful)
i tested it locally with a DB i constructed myself from just the packages i had installed, but you'll probably want to test it yourself
i don't know of any packages that contain files outside of `$PREFIX` but i added a case for it anyway
hopefully the code makes sense, i added a couple of comments just in case
that 1 very long `awk` line that includes `$PREFIX` and all of its grandparents isn't very elegant to look at, i'm not sure how to fix that but it works well