### PR TITLE
db builder: allow files outside of $PREFIX

### DIFF
--- a/update-whatprovides-db.sh
+++ b/update-whatprovides-db.sh
@@ -9,9 +9,9 @@ set -e -u
 : "${TERMUX_PREFIX:="/data/data/com.termux/files/usr"}"
 
 list_files() {
-	dpkg-deb -c "${1}" | grep -o "${TERMUX_PREFIX//./\\.}/.\+" \
-		| sed -E 's@(.*) ->..*@\1@g;s@/$@@g' \
-		| xargs -rd\\n realpath -sm --relative-base="$TERMUX_PREFIX" --
+	dpkg-deb --fsys-tarfile "${1}" | tar -t | cut -b2- \
+		| xargs -rd\\n realpath -sm --relative-base="$TERMUX_PREFIX" -- \
+		| grep -vEx '[./]|/data(/data(/com\.termux(/files)?)?)?'
 }
 
 write_sql_script() {


### PR DESCRIPTION
just in case! the apt cache is already outside of it so why not!
i think using `dpkg-deb --fsys-tarfile "${1}" | tar -t | cut -b2-` is more stable than trying to parse `dpkg-deb -c` output anyway